### PR TITLE
Add standalone todo list page with date and completion tracking

### DIFF
--- a/todo.html
+++ b/todo.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Todo List</title>
+    <style>
+        body { font-family: Arial, sans-serif; background-color: #f0f0f0; margin: 0; padding: 20px; }
+        .container { max-width: 600px; margin: auto; background: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+        h1 { text-align: center; margin-bottom: 20px; }
+        .input-group { display: flex; }
+        .input-group input { flex: 1; padding: 10px; font-size: 16px; }
+        .input-group button { padding: 10px 20px; font-size: 16px; }
+        ul { list-style: none; padding: 0; }
+        li { background: #fafafa; margin-top: 10px; padding: 10px; display: flex; align-items: center; border-radius: 4px; }
+        li.completed span { text-decoration: line-through; color: #888; }
+        li span { margin-left: 10px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1 id="current-date"></h1>
+        <div class="input-group">
+            <input type="text" id="task-input" placeholder="เพิ่มงานใหม่...">
+            <button id="add-task">Add Task</button>
+        </div>
+
+        <h2>สิ่งที่ต้องทำ</h2>
+        <ul id="todo-list"></ul>
+
+        <h2>ทำเสร็จแล้ว</h2>
+        <ul id="done-list"></ul>
+    </div>
+
+    <script>
+        function updateCurrentDate() {
+            const now = new Date();
+            const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+            document.getElementById('current-date').textContent = now.toLocaleDateString('th-TH', options);
+        }
+        updateCurrentDate();
+
+        const taskInput = document.getElementById('task-input');
+        const addTaskButton = document.getElementById('add-task');
+        const todoList = document.getElementById('todo-list');
+        const doneList = document.getElementById('done-list');
+
+        function createTaskElement(text) {
+            const li = document.createElement('li');
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            const span = document.createElement('span');
+            span.textContent = text;
+            checkbox.addEventListener('change', () => {
+                if (checkbox.checked) {
+                    doneList.appendChild(li);
+                    li.classList.add('completed');
+                } else {
+                    todoList.appendChild(li);
+                    li.classList.remove('completed');
+                }
+            });
+            li.appendChild(checkbox);
+            li.appendChild(span);
+            return li;
+        }
+
+        function addTask() {
+            const text = taskInput.value.trim();
+            if (text !== '') {
+                const li = createTaskElement(text);
+                todoList.appendChild(li);
+                taskInput.value = '';
+            }
+        }
+
+        addTaskButton.addEventListener('click', addTask);
+        taskInput.addEventListener('keypress', e => {
+            if (e.key === 'Enter') {
+                addTask();
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Create `todo.html` page showing current date and day at top
- Implement add-task input with checkbox to move tasks to completed list

## Testing
- `npx --yes htmlhint@latest todo.html` *(fails: 403 Forbidden)*
- `php -l todo.html`


------
https://chatgpt.com/codex/tasks/task_e_68aad2c46dac8327a5eb8711de31d715